### PR TITLE
[#48] Jackson 호환성을 위한 DTO 클래스 설정 변경

### DIFF
--- a/src/main/java/com/ssibongee/daangnmarket/member/dto/PasswordRequest.java
+++ b/src/main/java/com/ssibongee/daangnmarket/member/dto/PasswordRequest.java
@@ -1,22 +1,22 @@
 package com.ssibongee.daangnmarket.member.dto;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Pattern;
 
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class PasswordRequest {
 
     @NotEmpty
     @Pattern(message = "최소 한개 이상의 대소문자와 숫자, 특수문자를 포함한 8자 이상 16자 이하의 비밀번호를 입력해야 합니다.",
             regexp = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#!~$%^&-+=()])(?=\\S+$).{8,16}$")
-    private final String oldPassword;
+    private String oldPassword;
 
     @NotEmpty
     @Pattern(message = "최소 한개 이상의 대소문자와 숫자, 특수문자를 포함한 8자 이상 16자 이하의 비밀번호를 입력해야 합니다.",
             regexp = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#!~$%^&-+=()])(?=\\S+$).{8,16}$")
-    private final String newPassword;
+    private String newPassword;
 }

--- a/src/main/java/com/ssibongee/daangnmarket/member/dto/ProfileResponse.java
+++ b/src/main/java/com/ssibongee/daangnmarket/member/dto/ProfileResponse.java
@@ -10,13 +10,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ProfileResponse {
 
-    private final Long id;
     private final String email;
     private final String nickname;
 
     public static ProfileResponse of(Member member) {
         return ProfileResponse.builder()
-                .id(member.getId())
                 .email(member.getEmail())
                 .nickname(member.getNickname())
                 .build();

--- a/src/main/java/com/ssibongee/daangnmarket/post/dto/PostRequest.java
+++ b/src/main/java/com/ssibongee/daangnmarket/post/dto/PostRequest.java
@@ -3,17 +3,14 @@ package com.ssibongee.daangnmarket.post.dto;
 import com.ssibongee.daangnmarket.member.domain.entity.Member;
 import com.ssibongee.daangnmarket.post.domain.entity.Post;
 import com.ssibongee.daangnmarket.post.domain.entity.TradeStatus;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.validator.constraints.Length;
 
 import javax.validation.constraints.NotEmpty;
 
 @Builder
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class PostRequest {
 


### PR DESCRIPTION
- Jackson의 ObjectMapping을 위해 DTO 클래스들에 AccessLevel이 private인 기본 생성자 추가
- 반환시 불필요한 필드 속성 제거