### PR TITLE
[#47] 사용자 비밀번호 변경시 예외처리

### DIFF
--- a/src/main/java/com/ssibongee/daangnmarket/commons/advice/ExceptionAdvice.java
+++ b/src/main/java/com/ssibongee/daangnmarket/commons/advice/ExceptionAdvice.java
@@ -1,6 +1,7 @@
 package com.ssibongee.daangnmarket.commons.advice;
 
 import com.ssibongee.daangnmarket.member.exception.MemberNotFoundException;
+import com.ssibongee.daangnmarket.member.exception.PasswordNotMatchedException;
 import com.ssibongee.daangnmarket.member.exception.UnAuthenticatedAccessException;
 import com.ssibongee.daangnmarket.member.exception.UnAuthorizedAccessException;
 import com.ssibongee.daangnmarket.post.exception.AreaInfoNotDefinedException;
@@ -51,5 +52,10 @@ public class ExceptionAdvice {
     @ExceptionHandler(UnAuthenticatedAccessException.class)
     public ResponseEntity<HttpStatus> unAuthenticatedAccessException() {
         return RESPONSE_UNAUTHORIZED;
+    }
+
+    @ExceptionHandler(PasswordNotMatchedException.class)
+    public ResponseEntity<HttpStatus> passwordNotMatchedException() {
+        return RESPONSE_FORBIDDEN;
     }
 }

--- a/src/main/java/com/ssibongee/daangnmarket/commons/advice/ExceptionAdvice.java
+++ b/src/main/java/com/ssibongee/daangnmarket/commons/advice/ExceptionAdvice.java
@@ -56,6 +56,6 @@ public class ExceptionAdvice {
 
     @ExceptionHandler(PasswordNotMatchedException.class)
     public ResponseEntity<HttpStatus> passwordNotMatchedException() {
-        return RESPONSE_FORBIDDEN;
+        return RESPONSE_BAD_REQUEST;
     }
 }

--- a/src/main/java/com/ssibongee/daangnmarket/member/exception/PasswordNotMatchedException.java
+++ b/src/main/java/com/ssibongee/daangnmarket/member/exception/PasswordNotMatchedException.java
@@ -1,0 +1,15 @@
+package com.ssibongee.daangnmarket.member.exception;
+
+public class PasswordNotMatchedException extends RuntimeException {
+
+    public PasswordNotMatchedException() {
+    }
+
+    public PasswordNotMatchedException(String message) {
+        super(message);
+    }
+
+    public PasswordNotMatchedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/ssibongee/daangnmarket/member/service/GeneralMemberService.java
+++ b/src/main/java/com/ssibongee/daangnmarket/member/service/GeneralMemberService.java
@@ -7,6 +7,7 @@ import com.ssibongee.daangnmarket.member.dto.PasswordRequest;
 import com.ssibongee.daangnmarket.member.dto.ProfileRequest;
 import com.ssibongee.daangnmarket.member.domain.entity.Member;
 import com.ssibongee.daangnmarket.member.domain.repository.MemberRepository;
+import com.ssibongee.daangnmarket.member.exception.PasswordNotMatchedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -55,9 +56,9 @@ public class GeneralMemberService implements MemberService {
 
         if(passwordEncoder.matches(passwordRequest.getOldPassword(), member.getPassword())) {
             return true;
+        } else {
+            throw new PasswordNotMatchedException();
         }
-
-        return false;
     }
 
     @Override


### PR DESCRIPTION
-  사용자의 기존 비밀번호가 일치하지 않을 경우 비밀번호를 변경하지 않고 `PasswordNotMatchedException`을 발생시키도록 수정
