### PR TITLE
게시글 검색 기능 구현

### DIFF
--- a/src/main/java/com/ssibongee/daangnmarket/post/controller/PostSearchController.java
+++ b/src/main/java/com/ssibongee/daangnmarket/post/controller/PostSearchController.java
@@ -3,6 +3,7 @@ package com.ssibongee.daangnmarket.post.controller;
 import com.ssibongee.daangnmarket.commons.annotation.LoginMember;
 import com.ssibongee.daangnmarket.commons.annotation.LoginRequired;
 import com.ssibongee.daangnmarket.member.domain.entity.Member;
+import com.ssibongee.daangnmarket.post.dto.AddressRequest;
 import com.ssibongee.daangnmarket.post.dto.PostPageResponse;
 import com.ssibongee.daangnmarket.post.service.TradePostSearchService;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,6 +27,15 @@ public class PostSearchController {
     public ResponseEntity<PostPageResponse> getTradePosts(@LoginMember Member member, Pageable pageable) {
 
         PostPageResponse page = tradePostSearchService.findAllByMemberAddress(member, pageable);
+
+        return ResponseEntity.ok(page);
+    }
+
+    @LoginRequired
+    @GetMapping("/address")
+    public ResponseEntity<PostPageResponse> getTradePostsByAddress(@Valid AddressRequest address, Pageable pageable) {
+
+        PostPageResponse page = tradePostSearchService.findAllByAddress(address, pageable);
 
         return ResponseEntity.ok(page);
     }

--- a/src/main/java/com/ssibongee/daangnmarket/post/controller/PostSearchController.java
+++ b/src/main/java/com/ssibongee/daangnmarket/post/controller/PostSearchController.java
@@ -47,7 +47,7 @@ public class PostSearchController {
     public ResponseEntity<PostPageResponse> getTradePostsByCategory(@RequestParam("category") @NotEmpty String category,
                                                                     @LoginMember Member member, Pageable pageable) {
 
-        PostPageResponse page = tradePostSearchService.findALlByCategory(category, member, pageable);
+        PostPageResponse page = tradePostSearchService.findAllByCategory(category, member, pageable);
 
         return ResponseEntity.ok(page);
     }

--- a/src/main/java/com/ssibongee/daangnmarket/post/controller/PostSearchController.java
+++ b/src/main/java/com/ssibongee/daangnmarket/post/controller/PostSearchController.java
@@ -45,7 +45,8 @@ public class PostSearchController {
     @LoginRequired
     @GetMapping("/categories")
     public ResponseEntity<PostPageResponse> getTradePostsByCategory(@RequestParam("category") @NotEmpty String category,
-                                                                    @LoginMember Member member, Pageable pageable) {
+                                                                    @LoginMember Member member,
+                                                                    Pageable pageable) {
 
         PostPageResponse page = tradePostSearchService.findAllByCategory(category, member, pageable);
 

--- a/src/main/java/com/ssibongee/daangnmarket/post/controller/PostSearchController.java
+++ b/src/main/java/com/ssibongee/daangnmarket/post/controller/PostSearchController.java
@@ -11,9 +11,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
 
 @RestController
 @RequiredArgsConstructor
@@ -36,6 +38,16 @@ public class PostSearchController {
     public ResponseEntity<PostPageResponse> getTradePostsByAddress(@Valid AddressRequest address, Pageable pageable) {
 
         PostPageResponse page = tradePostSearchService.findAllByAddress(address, pageable);
+
+        return ResponseEntity.ok(page);
+    }
+
+    @LoginRequired
+    @GetMapping("/categories")
+    public ResponseEntity<PostPageResponse> getTradePostsByCategory(@RequestParam("category") @NotEmpty String category,
+                                                                    @LoginMember Member member, Pageable pageable) {
+
+        PostPageResponse page = tradePostSearchService.findALlByCategory(category, member, pageable);
 
         return ResponseEntity.ok(page);
     }

--- a/src/main/java/com/ssibongee/daangnmarket/post/controller/PostSearchController.java
+++ b/src/main/java/com/ssibongee/daangnmarket/post/controller/PostSearchController.java
@@ -1,0 +1,30 @@
+package com.ssibongee.daangnmarket.post.controller;
+
+import com.ssibongee.daangnmarket.commons.annotation.LoginMember;
+import com.ssibongee.daangnmarket.commons.annotation.LoginRequired;
+import com.ssibongee.daangnmarket.member.domain.entity.Member;
+import com.ssibongee.daangnmarket.post.dto.PostPageResponse;
+import com.ssibongee.daangnmarket.post.service.TradePostSearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/searches")
+public class PostSearchController {
+
+    private final TradePostSearchService tradePostSearchService;
+
+    @LoginRequired
+    @GetMapping
+    public ResponseEntity<PostPageResponse> getTradePosts(@LoginMember Member member, Pageable pageable) {
+
+        PostPageResponse page = tradePostSearchService.findAllByMemberAddress(member, pageable);
+
+        return ResponseEntity.ok(page);
+    }
+}

--- a/src/main/java/com/ssibongee/daangnmarket/post/domain/repository/PostSearchRepository.java
+++ b/src/main/java/com/ssibongee/daangnmarket/post/domain/repository/PostSearchRepository.java
@@ -1,0 +1,14 @@
+package com.ssibongee.daangnmarket.post.domain.repository;
+
+import com.ssibongee.daangnmarket.post.domain.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface PostSearchRepository extends JpaRepository<Post, Long> {
+
+    @Query(value = "SELECT post FROM Post post JOIN FETCH post.author WHERE post.address.state=:state AND post.address.city=:city AND post.address.town=:town",
+    countQuery = "SELECT COUNT(*) FROM Post post WHERE post.address.state=:state AND post.address.city=:city AND post.address.town=:town")
+    public Page<Post> findAllByMemberAddress(String state, String city, String town, Pageable pageable);
+}

--- a/src/main/java/com/ssibongee/daangnmarket/post/domain/repository/PostSearchRepository.java
+++ b/src/main/java/com/ssibongee/daangnmarket/post/domain/repository/PostSearchRepository.java
@@ -9,6 +9,10 @@ import org.springframework.data.jpa.repository.Query;
 public interface PostSearchRepository extends JpaRepository<Post, Long> {
 
     @Query(value = "SELECT post FROM Post post JOIN FETCH post.author WHERE post.address.state=:state AND post.address.city=:city AND post.address.town=:town",
-    countQuery = "SELECT COUNT(*) FROM Post post WHERE post.address.state=:state AND post.address.city=:city AND post.address.town=:town")
+            countQuery = "SELECT COUNT(*) FROM Post post WHERE post.address.state=:state AND post.address.city=:city AND post.address.town=:town")
     public Page<Post> findAllByMemberAddress(String state, String city, String town, Pageable pageable);
+
+    @Query(value = "SELECT post FROM Post post JOIN FETCH post.author JOIN FETCH  post.category WHERE post.address.state=:state AND post.address.city=:city AND post.address.town=:town AND post.category.categoryName=:category",
+            countQuery = "SELECT COUNT(*) FROM Post post WHERE post.address.state=:state AND post.address.city=:city AND post.address.town=:town AND post.category.categoryName=:category")
+    public Page<Post> findAllByCategory(String category, String state, String city, String town, Pageable pageable);
 }

--- a/src/main/java/com/ssibongee/daangnmarket/post/dto/AddressRequest.java
+++ b/src/main/java/com/ssibongee/daangnmarket/post/dto/AddressRequest.java
@@ -1,0 +1,36 @@
+package com.ssibongee.daangnmarket.post.dto;
+
+import com.ssibongee.daangnmarket.post.domain.entity.Address;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotEmpty;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AddressRequest {
+
+    @NotEmpty
+    private String state;
+
+    @NotEmpty
+    private String city;
+
+    @NotEmpty
+    private String town;
+
+    public AddressRequest(String state, String city, String town) {
+        this.state = state;
+        this.city = city;
+        this.town = town;
+    }
+
+    public static Address toEntity(AddressRequest address) {
+        return Address.builder()
+                .state(address.getState())
+                .city(address.getCity())
+                .town(address.getTown())
+                .build();
+    }
+}

--- a/src/main/java/com/ssibongee/daangnmarket/post/dto/PostPageResponse.java
+++ b/src/main/java/com/ssibongee/daangnmarket/post/dto/PostPageResponse.java
@@ -1,0 +1,22 @@
+package com.ssibongee.daangnmarket.post.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class PostPageResponse {
+
+    private int totalPage;
+    private int currentPage;
+    private List<PostResponse> postResponses = new ArrayList<>();
+
+    @Builder
+    public PostPageResponse(int totalPage, int currentPage, List<PostResponse> postResponses) {
+        this.totalPage = totalPage;
+        this.currentPage = currentPage;
+        this.postResponses = postResponses;
+    }
+}

--- a/src/main/java/com/ssibongee/daangnmarket/post/service/PostSearchService.java
+++ b/src/main/java/com/ssibongee/daangnmarket/post/service/PostSearchService.java
@@ -10,4 +10,6 @@ public interface PostSearchService {
     public PostPageResponse findAllByMemberAddress(Member member, Pageable pageable);
 
     public PostPageResponse findAllByAddress(AddressRequest address, Pageable pageable);
+
+    public PostPageResponse findALlByCategory(String category, Member member, Pageable pageable);
 }

--- a/src/main/java/com/ssibongee/daangnmarket/post/service/PostSearchService.java
+++ b/src/main/java/com/ssibongee/daangnmarket/post/service/PostSearchService.java
@@ -11,5 +11,5 @@ public interface PostSearchService {
 
     public PostPageResponse findAllByAddress(AddressRequest address, Pageable pageable);
 
-    public PostPageResponse findALlByCategory(String category, Member member, Pageable pageable);
+    public PostPageResponse findAllByCategory(String category, Member member, Pageable pageable);
 }

--- a/src/main/java/com/ssibongee/daangnmarket/post/service/PostSearchService.java
+++ b/src/main/java/com/ssibongee/daangnmarket/post/service/PostSearchService.java
@@ -1,10 +1,13 @@
 package com.ssibongee.daangnmarket.post.service;
 
 import com.ssibongee.daangnmarket.member.domain.entity.Member;
+import com.ssibongee.daangnmarket.post.dto.AddressRequest;
 import com.ssibongee.daangnmarket.post.dto.PostPageResponse;
 import org.springframework.data.domain.Pageable;
 
 public interface PostSearchService {
 
     public PostPageResponse findAllByMemberAddress(Member member, Pageable pageable);
+
+    public PostPageResponse findAllByAddress(AddressRequest address, Pageable pageable);
 }

--- a/src/main/java/com/ssibongee/daangnmarket/post/service/PostSearchService.java
+++ b/src/main/java/com/ssibongee/daangnmarket/post/service/PostSearchService.java
@@ -1,0 +1,10 @@
+package com.ssibongee.daangnmarket.post.service;
+
+import com.ssibongee.daangnmarket.member.domain.entity.Member;
+import com.ssibongee.daangnmarket.post.dto.PostPageResponse;
+import org.springframework.data.domain.Pageable;
+
+public interface PostSearchService {
+
+    public PostPageResponse findAllByMemberAddress(Member member, Pageable pageable);
+}

--- a/src/main/java/com/ssibongee/daangnmarket/post/service/TradePostSearchService.java
+++ b/src/main/java/com/ssibongee/daangnmarket/post/service/TradePostSearchService.java
@@ -1,0 +1,39 @@
+package com.ssibongee.daangnmarket.post.service;
+
+import com.ssibongee.daangnmarket.commons.annotation.AreaInfoRequired;
+import com.ssibongee.daangnmarket.member.domain.entity.Member;
+import com.ssibongee.daangnmarket.post.domain.entity.Address;
+import com.ssibongee.daangnmarket.post.domain.entity.Post;
+import com.ssibongee.daangnmarket.post.domain.repository.PostSearchRepository;
+import com.ssibongee.daangnmarket.post.dto.PostPageResponse;
+import com.ssibongee.daangnmarket.post.dto.PostResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TradePostSearchService implements PostSearchService {
+
+    private final PostSearchRepository postSearchRepository;
+
+    @Override
+    @AreaInfoRequired
+    public PostPageResponse findAllByMemberAddress(Member member, Pageable pageable) {
+
+        Address address = member.getAddress();
+        Page<Post> posts = postSearchRepository.findAllByMemberAddress(address.getState(), address.getCity(), address.getTown(), pageable);
+
+        List<PostResponse> postResponses = posts.getContent().stream().map(PostResponse::of) .collect(Collectors.toList());
+
+        return PostPageResponse.builder()
+                .totalPage(posts.getTotalPages())
+                .currentPage(pageable.getPageNumber())
+                .postResponses(postResponses)
+                .build();
+    }
+}

--- a/src/main/java/com/ssibongee/daangnmarket/post/service/TradePostSearchService.java
+++ b/src/main/java/com/ssibongee/daangnmarket/post/service/TradePostSearchService.java
@@ -5,6 +5,7 @@ import com.ssibongee.daangnmarket.member.domain.entity.Member;
 import com.ssibongee.daangnmarket.post.domain.entity.Address;
 import com.ssibongee.daangnmarket.post.domain.entity.Post;
 import com.ssibongee.daangnmarket.post.domain.repository.PostSearchRepository;
+import com.ssibongee.daangnmarket.post.dto.AddressRequest;
 import com.ssibongee.daangnmarket.post.dto.PostPageResponse;
 import com.ssibongee.daangnmarket.post.dto.PostResponse;
 import lombok.RequiredArgsConstructor;
@@ -25,10 +26,20 @@ public class TradePostSearchService implements PostSearchService {
     @AreaInfoRequired
     public PostPageResponse findAllByMemberAddress(Member member, Pageable pageable) {
 
-        Address address = member.getAddress();
+        return getPagePostResponse(member.getAddress(), pageable);
+    }
+
+    @Override
+    public PostPageResponse findAllByAddress(AddressRequest address, Pageable pageable) {
+
+        return getPagePostResponse(AddressRequest.toEntity(address), pageable);
+    }
+
+    private PostPageResponse getPagePostResponse(Address address, Pageable pageable) {
+
         Page<Post> posts = postSearchRepository.findAllByMemberAddress(address.getState(), address.getCity(), address.getTown(), pageable);
 
-        List<PostResponse> postResponses = posts.getContent().stream().map(PostResponse::of) .collect(Collectors.toList());
+        List<PostResponse> postResponses = posts.getContent().stream().map(PostResponse::of).collect(Collectors.toList());
 
         return PostPageResponse.builder()
                 .totalPage(posts.getTotalPages())

--- a/src/main/java/com/ssibongee/daangnmarket/post/service/TradePostSearchService.java
+++ b/src/main/java/com/ssibongee/daangnmarket/post/service/TradePostSearchService.java
@@ -42,7 +42,7 @@ public class TradePostSearchService implements PostSearchService {
 
     @Override
     @AreaInfoRequired
-    public PostPageResponse findALlByCategory(String category, Member member, Pageable pageable) {
+    public PostPageResponse findAllByCategory(String category, Member member, Pageable pageable) {
 
         Address address = member.getAddress();
         Page<Post> posts = postSearchRepository.findAllByCategory(category, address.getState(), address.getCity(), address.getTown(), pageable);

--- a/src/main/java/com/ssibongee/daangnmarket/post/service/TradePostSearchService.java
+++ b/src/main/java/com/ssibongee/daangnmarket/post/service/TradePostSearchService.java
@@ -26,18 +26,31 @@ public class TradePostSearchService implements PostSearchService {
     @AreaInfoRequired
     public PostPageResponse findAllByMemberAddress(Member member, Pageable pageable) {
 
-        return getPagePostResponse(member.getAddress(), pageable);
+        Address address = member.getAddress();
+        Page<Post> posts = postSearchRepository.findAllByMemberAddress(address.getState(), address.getCity(), address.getTown(), pageable);
+
+        return getPostPageResponse(posts, pageable);
     }
 
     @Override
     public PostPageResponse findAllByAddress(AddressRequest address, Pageable pageable) {
 
-        return getPagePostResponse(AddressRequest.toEntity(address), pageable);
+        Page<Post> posts = postSearchRepository.findAllByMemberAddress(address.getState(), address.getCity(), address.getTown(), pageable);
+
+        return getPostPageResponse(posts, pageable);
     }
 
-    private PostPageResponse getPagePostResponse(Address address, Pageable pageable) {
+    @Override
+    @AreaInfoRequired
+    public PostPageResponse findALlByCategory(String category, Member member, Pageable pageable) {
 
-        Page<Post> posts = postSearchRepository.findAllByMemberAddress(address.getState(), address.getCity(), address.getTown(), pageable);
+        Address address = member.getAddress();
+        Page<Post> posts = postSearchRepository.findAllByCategory(category, address.getState(), address.getCity(), address.getTown(), pageable);
+
+        return getPostPageResponse(posts, pageable);
+    }
+
+    private PostPageResponse getPostPageResponse(Page<Post> posts, Pageable pageable) {
 
         List<PostResponse> postResponses = posts.getContent().stream().map(PostResponse::of).collect(Collectors.toList());
 


### PR DESCRIPTION
- 한 페이지당 20개의 글을 읽어오는 것을 전제로한다.
- 기본적으로 메인페이지는 로그인한 사용자의 지역을 기반으로 검색한 결과를 보여준다.
- 사용자는 특정 지역을 기준으로 검색한 결과를 조회할 수 있다.
- 사용자는 현재 사용자의 지역에서 특정 카테고리를 기반으로 검색한 결과를 조회할 수 있다.

검색을 위한 쿼리는 다음과 같이 주어진다.
- 사용자의 지역을 기반으로 기본 검색 : `/searches?page=0&size=20`
- 특정 지역을 기준으로 검색 : `/searches/address?state=서울특별시&city=관악구&town=은천동&page=0&size=20`
- 사용자의 지역을 기반으로 카테고리를 이용한 검색 : `/searches/categories?category=디지털/가전&page=0&size=20`