### PR TITLE
[#65] 거래 게시글 이미지 업로드 기능 구현 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,12 @@
             <artifactId>spring-restdocs-mockmvc</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-aws-context</artifactId>
+            <version>2.2.6.RELEASE</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/ssibongee/daangnmarket/commons/HttpStatusResponseEntity.java
+++ b/src/main/java/com/ssibongee/daangnmarket/commons/HttpStatusResponseEntity.java
@@ -11,4 +11,5 @@ public class HttpStatusResponseEntity {
     public static final ResponseEntity<HttpStatus> RESPONSE_NOT_FOUND = ResponseEntity.status(HttpStatus.NOT_FOUND).build();
     public static final ResponseEntity<HttpStatus> RESPONSE_UNAUTHORIZED = ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     public static final ResponseEntity<HttpStatus> RESPONSE_FORBIDDEN = ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+    public static final ResponseEntity<HttpStatus> RESPONSE_PAYLOAD_TOO_LARGE = ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).build();
 }

--- a/src/main/java/com/ssibongee/daangnmarket/commons/advice/ExceptionAdvice.java
+++ b/src/main/java/com/ssibongee/daangnmarket/commons/advice/ExceptionAdvice.java
@@ -7,6 +7,7 @@ import com.ssibongee.daangnmarket.member.exception.UnAuthorizedAccessException;
 import com.ssibongee.daangnmarket.post.exception.AreaInfoNotDefinedException;
 import com.ssibongee.daangnmarket.post.exception.CategoryNotFoundException;
 import com.ssibongee.daangnmarket.post.exception.PostNotFoundException;
+import org.apache.tomcat.util.http.fileupload.impl.FileSizeLimitExceededException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -57,5 +58,10 @@ public class ExceptionAdvice {
     @ExceptionHandler(PasswordNotMatchedException.class)
     public ResponseEntity<HttpStatus> passwordNotMatchedException() {
         return RESPONSE_BAD_REQUEST;
+    }
+
+    @ExceptionHandler(FileSizeLimitExceededException.class)
+    public ResponseEntity<HttpStatus> fileSizeLimitExceededException() {
+        return RESPONSE_PAYLOAD_TOO_LARGE;
     }
 }

--- a/src/main/java/com/ssibongee/daangnmarket/commons/config/DataSourceConfig.java
+++ b/src/main/java/com/ssibongee/daangnmarket/commons/config/DataSourceConfig.java
@@ -2,9 +2,11 @@ package com.ssibongee.daangnmarket.commons.config;
 
 import com.ssibongee.daangnmarket.commons.util.RoutingDataSource;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.*;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
@@ -74,4 +76,12 @@ public class DataSourceConfig {
     public DataSource dataSource() {
         return new LazyConnectionDataSourceProxy(routingDataSource());
     }
+
+    @Bean
+    public JdbcTemplate jdbcTemplate(@Qualifier("masterDataSource") DataSource dataSource) {
+        JdbcTemplate jdbcTemplate = new JdbcTemplate();
+        jdbcTemplate.setDataSource(dataSource);
+        return jdbcTemplate;
+    }
+
 }

--- a/src/main/java/com/ssibongee/daangnmarket/commons/properties/AwsS3Properties.java
+++ b/src/main/java/com/ssibongee/daangnmarket/commons/properties/AwsS3Properties.java
@@ -1,0 +1,21 @@
+package com.ssibongee.daangnmarket.commons.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "aws.s3")
+public class AwsS3Properties {
+
+    private String accessKey;
+    private String secretKey;
+    private String bucket;
+    private String region;
+    private String uploadPath;
+    private String endPoint;
+}
+

--- a/src/main/java/com/ssibongee/daangnmarket/image/config/AmazonS3Config.java
+++ b/src/main/java/com/ssibongee/daangnmarket/image/config/AmazonS3Config.java
@@ -1,0 +1,28 @@
+package com.ssibongee.daangnmarket.image.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.ssibongee.daangnmarket.commons.properties.AwsS3Properties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class AmazonS3Config {
+
+    private final AwsS3Properties properties;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        return AmazonS3ClientBuilder.standard()
+                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(properties.getEndPoint(), properties.getRegion()))
+                .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(properties.getAccessKey(), properties.getSecretKey())))
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/ssibongee/daangnmarket/image/controller/PostImageController.java
+++ b/src/main/java/com/ssibongee/daangnmarket/image/controller/PostImageController.java
@@ -1,0 +1,31 @@
+package com.ssibongee.daangnmarket.image.controller;
+
+import com.ssibongee.daangnmarket.commons.annotation.LoginRequired;
+import com.ssibongee.daangnmarket.image.service.ImageFileUploadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+import static com.ssibongee.daangnmarket.commons.HttpStatusResponseEntity.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/posts")
+public class PostImageController {
+
+    private final ImageFileUploadService imageFileUploadService;
+
+    @LoginRequired
+    @PostMapping("/{postId}/images")
+    public ResponseEntity<HttpStatus> uploadImages(@PathVariable Long postId,
+                                                   @RequestParam("file") List<MultipartFile> files) throws IOException {
+        imageFileUploadService.upload(postId, files);
+
+        return RESPONSE_OK;
+    }
+}

--- a/src/main/java/com/ssibongee/daangnmarket/image/domain/entity/Image.java
+++ b/src/main/java/com/ssibongee/daangnmarket/image/domain/entity/Image.java
@@ -1,0 +1,42 @@
+package com.ssibongee.daangnmarket.image.domain.entity;
+
+import com.ssibongee.daangnmarket.commons.BaseTimeEntity;
+import com.ssibongee.daangnmarket.post.domain.entity.Post;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Image extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "IMAGE_ID")
+    private Long id;
+
+    @Column(name = "IMAGE_NAME")
+    private String name;
+
+    @Column(name = "IMAGE_URL")
+    private String url;
+
+    @Column(name = "IS_REMOVED")
+    private boolean removed;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "POST_ID")
+    private Post post;
+
+    @Builder
+    public Image(String name, String url, Post post) {
+        this.name = name;
+        this.url = url;
+        this.post = post;
+    }
+
+}

--- a/src/main/java/com/ssibongee/daangnmarket/image/domain/repository/ImageJdbcRepository.java
+++ b/src/main/java/com/ssibongee/daangnmarket/image/domain/repository/ImageJdbcRepository.java
@@ -1,0 +1,36 @@
+package com.ssibongee.daangnmarket.image.domain.repository;
+
+import com.ssibongee.daangnmarket.image.domain.entity.Image;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ImageJdbcRepository {
+
+    private static final String BULK_INSERT_SQL = "INSERT INTO " +
+            "`image`(`image_name` , `image_url`, `created_time`, `modified_time`, `post_id`, `is_removed`) " +
+            "VALUES(?, ?, ?, ?, ?, ?)";
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public void saveAll(List<Image> images) {
+        jdbcTemplate.batchUpdate(BULK_INSERT_SQL,
+                images,
+                images.size(),
+                (ps, image) -> {
+                    LocalDateTime now = LocalDateTime.now();
+                    ps.setString(1, image.getName());
+                    ps.setString(2, image.getUrl());
+                    ps.setTimestamp(3, Timestamp.valueOf(now));
+                    ps.setTimestamp(4, Timestamp.valueOf(now));
+                    ps.setLong(5, image.getPost().getId());
+                    ps.setBoolean(6, image.isRemoved());
+                });
+    }
+}

--- a/src/main/java/com/ssibongee/daangnmarket/image/domain/repository/ImageRepository.java
+++ b/src/main/java/com/ssibongee/daangnmarket/image/domain/repository/ImageRepository.java
@@ -1,0 +1,7 @@
+package com.ssibongee.daangnmarket.image.domain.repository;
+
+import com.ssibongee.daangnmarket.image.domain.entity.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+}

--- a/src/main/java/com/ssibongee/daangnmarket/image/exception/UnSupportedFileTypeException.java
+++ b/src/main/java/com/ssibongee/daangnmarket/image/exception/UnSupportedFileTypeException.java
@@ -1,0 +1,15 @@
+package com.ssibongee.daangnmarket.image.exception;
+
+public class UnSupportedFileTypeException extends RuntimeException {
+
+    public UnSupportedFileTypeException() {
+    }
+
+    public UnSupportedFileTypeException(String message) {
+        super(message);
+    }
+
+    public UnSupportedFileTypeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/ssibongee/daangnmarket/image/service/AwsS3Service.java
+++ b/src/main/java/com/ssibongee/daangnmarket/image/service/AwsS3Service.java
@@ -1,0 +1,47 @@
+package com.ssibongee.daangnmarket.image.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.util.IOUtils;
+import com.ssibongee.daangnmarket.commons.properties.AwsS3Properties;
+import com.ssibongee.daangnmarket.image.util.FileUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class AwsS3Service implements StorageService {
+
+    private final AwsS3Properties properties;
+
+    private final AmazonS3 client;
+
+    public String upload(MultipartFile file, String filename) throws IOException {
+        return putObjectToS3Storage(client, FileUtils.getFilePath(file, filename), file);
+    }
+
+    private String putObjectToS3Storage(AmazonS3 client, String filepath, MultipartFile file) throws IOException {
+        String bucket = properties.getBucket();
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        ByteArrayInputStream stream = getByteArrayInputStream(file, metadata);
+
+        client.putObject(new PutObjectRequest(bucket, filepath, stream, metadata)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+
+        return client.getUrl(bucket, filepath).toString();
+    }
+
+    private ByteArrayInputStream getByteArrayInputStream(MultipartFile file, ObjectMetadata metadata) throws IOException {
+        byte[] bytes = IOUtils.toByteArray(file.getInputStream());
+        metadata.setContentLength(bytes.length);
+        return new ByteArrayInputStream(bytes);
+    }
+
+}

--- a/src/main/java/com/ssibongee/daangnmarket/image/service/ImageFileUploadService.java
+++ b/src/main/java/com/ssibongee/daangnmarket/image/service/ImageFileUploadService.java
@@ -1,0 +1,52 @@
+package com.ssibongee.daangnmarket.image.service;
+
+import com.ssibongee.daangnmarket.image.domain.entity.Image;
+import com.ssibongee.daangnmarket.image.domain.repository.ImageJdbcRepository;
+import com.ssibongee.daangnmarket.image.util.FileUtils;
+import com.ssibongee.daangnmarket.post.domain.entity.Post;
+import com.ssibongee.daangnmarket.post.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ImageFileUploadService {
+
+    private final AwsS3Service awsS3Service;
+    private final PostService postService;
+    private final ImageJdbcRepository imageJdbcRepository;
+
+    @Transactional
+    public void upload(Long postId, List<MultipartFile> files) throws IOException {
+        Post post = postService.findPostById(postId);
+        upload(files, post);
+    }
+
+    private void upload(List<MultipartFile> files, Post post) throws IOException {
+        List<Image> images = uploadImageToStorageServer(files, post);
+        imageJdbcRepository.saveAll(images);
+    }
+
+    private List<Image> uploadImageToStorageServer(List<MultipartFile> files, Post post) throws IOException {
+        List<Image> images = new ArrayList<>();
+
+        for (MultipartFile file : files) {
+            String filename = FileUtils.getRandomFilename();
+            String filepath = awsS3Service.upload(file, filename);
+            images.add(Image.builder()
+                    .name(filename)
+                    .url(filepath)
+                    .post(post)
+                    .build());
+        }
+
+        return images;
+    }
+
+}

--- a/src/main/java/com/ssibongee/daangnmarket/image/service/StorageService.java
+++ b/src/main/java/com/ssibongee/daangnmarket/image/service/StorageService.java
@@ -1,0 +1,10 @@
+package com.ssibongee.daangnmarket.image.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+public interface StorageService {
+
+    public String upload(MultipartFile file, String filename) throws IOException;
+}

--- a/src/main/java/com/ssibongee/daangnmarket/image/util/FileType.java
+++ b/src/main/java/com/ssibongee/daangnmarket/image/util/FileType.java
@@ -1,0 +1,19 @@
+package com.ssibongee.daangnmarket.image.util;
+
+public enum FileType {
+
+    PNG("png"),
+    JPEG("jpeg"),
+    JPG("jpg"),
+    GIF("git");
+
+    private final String extension;
+    
+    FileType(String extension) {
+        this.extension = extension;
+    }
+
+    public String getExtension() {
+        return extension;
+    }
+}

--- a/src/main/java/com/ssibongee/daangnmarket/image/util/FileUtils.java
+++ b/src/main/java/com/ssibongee/daangnmarket/image/util/FileUtils.java
@@ -1,0 +1,34 @@
+package com.ssibongee.daangnmarket.image.util;
+
+import com.ssibongee.daangnmarket.image.exception.UnSupportedFileTypeException;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+
+public class FileUtils {
+
+    private static final String BASE_DIRECTORY = "image";
+
+    public static String getRandomFilename() {
+        return UUID.randomUUID().toString().replace("-", "");
+    }
+
+    public static String getFilePath(MultipartFile file, String filename) {
+        String extension = StringUtils.getFilenameExtension(Objects.requireNonNull(file.getOriginalFilename()));
+
+        if(!isValidFileType(extension)) {
+            throw new UnSupportedFileTypeException(extension + "은 지원하는 파일 형식이 아닙니다.");
+        }
+
+        return  BASE_DIRECTORY + "/" + filename + "." + extension;
+    }
+
+    private static boolean isValidFileType(String extension) {
+        return Arrays.stream(FileType.values())
+                .anyMatch(type -> type.getExtension().equals(extension));
+    }
+
+}


### PR DESCRIPTION
- AWS S3 API를 이용하여 NCP 오브젝트 스토리지에 이미지 파일 업로드 기능 구현 
- 여러개의 이미지 파일에 대한 정보를 `Image` 테이블에 Multi Value 쿼리 형태로 벌크 연산을 통해 처리할 수 있도록 문제 해결 
  - `Auto Increment` 를 이용한 식별자 생성 전략을 사용하는 경우 벌크 연산을 통해 성능 최적화가 불가능하다.
  - JPA의 벌크 연산은 일반적으로 생각하는 Multi Value 쿼리가 아닌 여러개의 쿼리를 묶어서 한번에 처리하는 방식이다.
  - 결과적으로 Multi Value 쿼리를 처리하기 위해서 MySQL에서는 JDBC URL에 `rewriteBatchedStatements`가 `true` 로 설정되어있음과 동시에 시퀀스 오브젝트를 제공하지 않기 때문에 시퀀스 테이블을 생성하는 방식을 사용하거나 
  - `JdbcTemplate` , `MyBatis` 등의 네이티브 SQL을 이용하는 방식이나 `QueryDsl-EntityQL` 등을 사용할 수 있다.
  - 현재 프로젝트에서는 `JdbcTemplate`을 이용한 방식으로 문제를 해결한다.