### PR TITLE
[#26] 거래 게시글을 지역을 기준으로 캐싱 적용하기

### DIFF
--- a/src/main/java/com/ssibongee/daangnmarket/post/dto/PostPageResponse.java
+++ b/src/main/java/com/ssibongee/daangnmarket/post/dto/PostPageResponse.java
@@ -1,12 +1,15 @@
 package com.ssibongee.daangnmarket.post.dto;
 
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostPageResponse {
 
     private int totalPage;

--- a/src/main/java/com/ssibongee/daangnmarket/post/service/TradePostSearchService.java
+++ b/src/main/java/com/ssibongee/daangnmarket/post/service/TradePostSearchService.java
@@ -9,12 +9,16 @@ import com.ssibongee.daangnmarket.post.dto.AddressRequest;
 import com.ssibongee.daangnmarket.post.dto.PostPageResponse;
 import com.ssibongee.daangnmarket.post.dto.PostResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.ssibongee.daangnmarket.commons.config.CacheKeyConfig.*;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +28,13 @@ public class TradePostSearchService implements PostSearchService {
 
     @Override
     @AreaInfoRequired
+    @Transactional(readOnly = true)
+    @Cacheable(
+            key = "#member.getAddress().state + '.' + #member.getAddress().city + '.' + #member.getAddress().town",
+            value = POST,
+            cacheManager = "redisCacheManager",
+            condition = "#pageable.pageNumber == 0"
+    )
     public PostPageResponse findAllByMemberAddress(Member member, Pageable pageable) {
 
         Address address = member.getAddress();
@@ -33,6 +44,13 @@ public class TradePostSearchService implements PostSearchService {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    @Cacheable(
+            key = "#member.getAddress().state + '.' + #member.getAddress().city + '.' + #member.getAddress().town",
+            value = POST,
+            cacheManager = "redisCacheManager",
+            condition = "#pageable.pageNumber == 0"
+    )
     public PostPageResponse findAllByAddress(AddressRequest address, Pageable pageable) {
 
         Page<Post> posts = postSearchRepository.findAllByMemberAddress(address.getState(), address.getCity(), address.getTown(), pageable);
@@ -42,6 +60,13 @@ public class TradePostSearchService implements PostSearchService {
 
     @Override
     @AreaInfoRequired
+    @Transactional(readOnly = true)
+    @Cacheable(
+            key = "#member.getAddress().state + '.' + #member.getAddress().city + '.' + #member.getAddress().town + '.' + #category",
+            value = POST,
+            cacheManager = "redisCacheManager",
+            condition = "#pageable.pageNumber == 0"
+    )
     public PostPageResponse findAllByCategory(String category, Member member, Pageable pageable) {
 
         Address address = member.getAddress();

--- a/src/main/java/com/ssibongee/daangnmarket/post/service/TradePostService.java
+++ b/src/main/java/com/ssibongee/daangnmarket/post/service/TradePostService.java
@@ -10,8 +10,12 @@ import com.ssibongee.daangnmarket.post.domain.entity.Post;
 import com.ssibongee.daangnmarket.post.domain.repository.PostRepository;
 import com.ssibongee.daangnmarket.member.service.LoginService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.ssibongee.daangnmarket.commons.config.CacheKeyConfig.POST;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +29,16 @@ public class TradePostService implements PostService {
     @Override
     @AreaInfoRequired
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(
+                    key = "#member.getAddress().state + '.' + #member.getAddress().city + '.' + #member.getAddress().town",
+                    value = POST
+            ),
+            @CacheEvict(
+                    key = "#member.getAddress().state + '.' + #member.getAddress().city + '.' + #member.getAddress().town + '.' + #postRequest.category",
+                    value = POST
+            )
+    })
     public void createNewPost(PostRequest postRequest, Member member) {
 
         Post post = postRequest.toEntity(member);
@@ -36,12 +50,23 @@ public class TradePostService implements PostService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Post findPostById(Long postId) {
         return postRepository.findPostById(postId).orElseThrow(PostNotFoundException::new);
     }
 
     @Override
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(
+                    key = "#member.getAddress().state + '.' + #member.getAddress().city + '.' + #member.getAddress().town",
+                    value = POST
+            ),
+            @CacheEvict(
+                    key = "#member.getAddress().state + '.' + #member.getAddress().city + '.' + #member.getAddress().town + '.' + #postRequest.category",
+                    value = POST
+            )
+    })
     public void updatePost(Post post, PostRequest postRequest) {
 
         if (isMatchedAuthor(post)) {
@@ -54,9 +79,19 @@ public class TradePostService implements PostService {
 
     @Override
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(
+                    key = "#member.getAddress().state + '.' + #member.getAddress().city + '.' + #member.getAddress().town",
+                    value = POST
+            ),
+            @CacheEvict(
+                    key = "#member.getAddress().state + '.' + #member.getAddress().city + '.' + #member.getAddress().town + '.' + #postRequest.category",
+                    value = POST
+            )
+    })
     public void removePost(Post post) {
 
-        if(isMatchedAuthor(post)) {
+        if (isMatchedAuthor(post)) {
             post.removePost();
         }
     }
@@ -66,7 +101,7 @@ public class TradePostService implements PostService {
 
         Member member = loginService.getLoginMember();
 
-        if(post.getAuthor() != member) {
+        if (post.getAuthor() != member) {
             throw new UnAuthorizedAccessException();
         }
 


### PR DESCRIPTION
- 거래 게시글 조회시 다음의 기준 통해 첫 페이지 조회에 대한 캐싱 적용
  - 사용자의 기본 지역정보를 통해 거래 게시글 목록을 조회하는 경우 : `state`.`city`.`town` 을 키 값으로 하여 캐싱
  - 사용자가 임의의 지역정보를 통해 거래 게시글 목록을 조회하는 경우 : `state`.`city`.`town` 을 키 값으로 하여 캐싱
  - 사용자의 기본 지역정보와 카테고리를 통해 거래 게시글 목록을 조회하는 경우 : `state`.`city`.`town`.`category` 을 키 값으로 하여 캐싱

- 새로운 거래 게시글 작성 및 거래 게시글 업데이트시 캐싱된 목록 제거 
  - 게시글의 정보를 바탕으로 `state`.`city`.`town` 와 `state`.`city`.`town`.`category`를 키 값으로 하는 캐싱된 데이터 제거 